### PR TITLE
ファイアーウォールなし環境への対応とSVN→Gitへの変更を実施

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cd redmine-centos-ansible
 ansible-playbook -i hosts site.yml
 ```
 
-10〜20分ほどでインストールが完了します。webブラウザで `http://サーバIPアドレス` にアクセスしてください。Redmineの画面が表示されるはずです。
+10〜20分ほどでインストールが完了します。webブラウザで `http://サーバIPアドレス/redmine` にアクセスしてください。Redmineの画面が表示されるはずです。
 
 
 ## ライセンス

--- a/group_vars/redmine-servers
+++ b/group_vars/redmine-servers
@@ -1,10 +1,12 @@
 # ----------------------------------------------------------------------
 # データベースの redmine ユーザーのパスワード (変更推奨)
-db_passwd_redmine: Must_be_changed!
+db_passwd_redmine: password
 # ----------------------------------------------------------------------
+# Redmineのバージョン
+redmine_version: 3.2.0
 
-# Redmineのチェックアウト元URL
-redmine_svn_url: http://svn.redmine.org/redmine/branches/3.2-stable
+# Redmineのクローン元URL
+redmine_git_url: https://github.com/redmine/redmine.git
 
 # Redmineのデプロイ先ディレクトリ
 redmine_dir: /var/lib/redmine

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -31,6 +31,8 @@
 - name: PassengerのApache用モジュールの設定を取得
   command:
     passenger-install-apache2-module --snippet
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
   register:
     passenger_snippet_vars
   changed_when: false

--- a/roles/redmine/tasks/main.yml
+++ b/roles/redmine/tasks/main.yml
@@ -1,8 +1,9 @@
-- name: Redmineのソースコードをチェックアウト
+- name: Redmineのソースコードをクローン
   sudo: yes
-  subversion:
-    repo={{ redmine_svn_url }}
+  git:
+    repo={{ redmine_git_url }}
     dest={{ redmine_dir }}
+    version={{ redmine_version }}
 
 - name: database.ymlの作成
   sudo: yes

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: そのほかのツールのインストール
   sudo: yes
   yum:
-    name='subversion,git'
+    name='git'
 
 - name: 作業ディレクトリ作成
   file: path={{ work_dir }}

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -16,13 +16,23 @@
   command: setenforce 0
   when: result.rc == 0
 
+- name: firewalldが起動しているか確認
+  sudo: yes
+  shell: firewall-cmd --state; echo $?
+  register: firewalld_is_running
+  ignore_errors: yes
+  changed_when: false
+  always_run: yes
+
 - name: firewalldでHTTPを許可
   sudo: yes
   command: firewall-cmd --zone=public --add-service=http --permanent
+  when: firewalld_is_running.stdout.find('not running') == -1
 
 - name: firewalldのポリシーをリロード
   sudo: yes
   command: firewall-cmd --reload
+  when: firewalld_is_running.stdout.find('not running') == -1
 
 - name: 開発ツールのインストール
   sudo: yes


### PR DESCRIPTION
以下3点の変更をしました。
よろしければマージしてください。
- passenger-install-apache2-moduleがパスに見つからないエラーになることがあるためenvironmentを追加
- firewalldが起動していない場合は、ファイアーウォールの設定をしないように変更
- 以下の理由により、RedmineのコードをSVNではなく、Gitでクローンするように変更
  - git cloneにて本Playbookを使うことから、既にGitが入っており、改めてSVNをインストール必要がない
  - Proxy環境において、環境変数のhttp_proxyを設定するだけで済む
