### PR TITLE
Specify to install bundler 1.17.3.

### DIFF
--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -50,6 +50,7 @@
   become: yes
   gem:
     name=bundler
+    version=1.17.3
     user_install=no
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"


### PR DESCRIPTION
Close: #8 
`bundler` インストール時に明示的に 2019/01/11 現在 `1.x.x` 系で最新の `1.17.3` を指定するようにしました。

Signed-off-by: Noriki Nakamura <noriki.nakamura@miraclelinux.com>