### PR TITLE
Use `result_database_yml is changed` notation instead of `result_database_yml|changed` notation.

### DIFF
--- a/roles/redmine/tasks/main.yml
+++ b/roles/redmine/tasks/main.yml
@@ -76,7 +76,7 @@
     RAILS_ENV: production
     REDMINE_LANG: ja
   when:
-    result_database_yml|changed
+    result_database_yml is changed
 
 - name: farend_basicテーマのダウンロード
   become: yes
@@ -93,7 +93,7 @@
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
     RAILS_ENV: production
   when:
-    result_database_yml|changed
+    result_database_yml is changed
 
 - name: デフォルトの言語を日本語に変更
   become: yes
@@ -104,7 +104,7 @@
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
     RAILS_ENV: production
   when:
-    result_database_yml|changed
+    result_database_yml is changed
 
 - name: ユーザー名の表示形式を「姓 名」に変更
   become: yes
@@ -115,7 +115,7 @@
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
     RAILS_ENV: production
   when:
-    result_database_yml|changed
+    result_database_yml is changed
 
 - name: 添付ファイルとリポジトリのエンコーディングを設定
   become: yes
@@ -126,7 +126,7 @@
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
     RAILS_ENV: production
   when:
-    result_database_yml|changed
+    result_database_yml is changed
 
 - name: 添付ファイルのサムネイルを表示
   become: yes
@@ -137,4 +137,4 @@
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
     RAILS_ENV: production
   when:
-    result_database_yml|changed
+    result_database_yml is changed


### PR DESCRIPTION
Ansible 2.9 以降では、`result|changed` という書き方ができないようです。
(現在は非推奨という警告が出るものの、利用できます。
代わりに、`result is changed` を利用してくださいとのことです。

実行時に以下の警告メッセージが出力されます。
```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|changed` instead use `result is changed`.
This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

これを抑制するためのパッチです。

Signed-off-by: Noriki Nakamura <noriki.nakamura@miraclelinux.com>