### PR TITLE
Use `sudo` as `become_method` instead of `su`.

### DIFF
--- a/roles/pg/tasks/main.yml
+++ b/roles/pg/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: PostgreSQL ユーザー作成
   become: yes
   become_user: postgres
-  become_method: su
+  become_method: sudo
   postgresql_user:
     name=redmine
     password={{ db_passwd_redmine }}
@@ -49,7 +49,7 @@
 - name: PostgreSQL データベース作成
   become: yes
   become_user: postgres
-  become_method: su
+  become_method: sudo
   postgresql_db:
     name=redmine
     encoding='UTF-8'


### PR DESCRIPTION
`README.md` の記載のとおり、ローカル環境に対して PlayBook を実行する場合、
`become_method` が `su` でも問題ないのですが、リモートホストに対して実行する
場合は以下のようなメッセージが表示され、失敗します。

```
TASK [pg : PostgreSQL ユーザー作成] *******************************************************************************************************
fatal: [xxx.xxx.xxx.xxx]: FAILED! => {"changed": false, "module_stderr": "Shared connection to xxx.xxx.xxx.xxx closed.\r\n", "module_stdout": "\r\nsu: 認証失敗\r\n", "msg": "MODULE FAILURE", "rc": 1}
```

`become_method` が `sudo` の場合だと、デフォルトの CentOS では、リモートホストに
対して実行する場合は`-K` オプションを付与し接続ユーザのパスワードを入力すれば、
`become_user` になることが可能なので、こちらの方が良いと思い、提案します。

Signed-off-by: Noriki Nakamura <noriki.nakamura@miraclelinux.com>